### PR TITLE
Solved iterator conversion error in JSONDeserializer.cpp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # A C++ implementation for using Prolog in ROS
 
+![ros](https://img.shields.io/badge/ROS-Kinetic-brightgreen.svg)
+
 ## Overview
 
 **Author(s): Ralf Kaestner</br>
@@ -18,26 +20,26 @@ This project provides a ROS server/client interface to Prolog.
   ```
   sudo apt-get install swi-prolog
   ```
- 
+
 - [jsoncpp](https://github.com/open-source-parsers/jsoncpp)
 
   ```
   sudo apt-get install libjsoncpp-dev
   ```
 
+- [roscpp-nodewrap](https://github.com/ethz-asl/roscpp-nodewrap)
+
+  ```shell
+  cd <path_to_your_catkin_space>
+  git clone https://github.com/ethz-asl/roscpp-nodewrap.git
+  ```
+
 ### Building
 
-Create a symlink in your catkin source folder, e.g.:
-
-  ```
-  ln -s ~/git/ros-prolog ~/catkin_ws/src
-  ```
-
-If you just need certain packages of this project:
-
-  ```
-  ln -s ~/git/ros-prolog/name_of_the_package ~/catkin_ws/src
-  ```
+```
+cd <path_to_your_catkin_space>
+catkin_make
+```
 
 ## Usage
 

--- a/prolog_serialization/src/JSONDeserializer.cpp
+++ b/prolog_serialization/src/JSONDeserializer.cpp
@@ -132,7 +132,7 @@ Program JSONDeserializer::valueToProgram(const Json::Value& value) const {
   if (value.isArray()) {
     std::list<Clause> clauses;
     
-    for (Json::Value::iterator it = value.begin(); it != value.end(); ++it)
+    for (Json::Value::const_iterator it = value.begin(); it != value.end(); ++it)
       clauses.push_back(valueToClause(*it));
     
     return Program(clauses);
@@ -250,7 +250,7 @@ Term JSONDeserializer::valueToTerm(const Json::Value& value) const {
   else if (value.isArray()) {
     std::list<Term> elements;
     
-    for (Json::Value::iterator it = value.begin(); it != value.end(); ++it)
+    for (Json::Value::const_iterator it = value.begin(); it != value.end(); ++it)
       elements.push_back(valueToTerm(*it));
     
     return Term(elements);


### PR DESCRIPTION
Hi, 

With the original code on Ubuntu 16.04LTS and Ros Kinetic we get `error: conversion from ‘Json::Value::const_iterator {aka Json::ValueConstIterator}’ to non-scalar type ‘Json::ValueIterator’ requested for(Json::ValueIterator it = root.begin() ; it != root.end() ; ++it)` in JSONDeserializer.cpp.  This pull request offers a solution to the problem. I also took the liberty to update the README with better dependency information as well as a clear and simple building instructions.

Thanks.
Best regards!